### PR TITLE
Chrome 26 doesn't need vendor prefixes anymore for transitions

### DIFF
--- a/_posts/2013-02-27-transitions.md
+++ b/_posts/2013-02-27-transitions.md
@@ -17,7 +17,7 @@ prefixed: true
      -moz-transition: width 1s linear .2s; /* 4 < Fx <16 */
       -ms-transition: width 1s linear .2s; /* IE 10 */
        -o-transition: width 1s linear .2s; /* 10.5 < Op < 12.1 */
-          transition: width 1s linear .2s; /* IE 10, Fx 16+, Op 12.1+ */
+          transition: width 1s linear .2s; /* IE 10, Ch 26+, Fx 16+, Op 12.1+ */
 }
 </code></pre>
 	<footer class="feature__footer">


### PR DESCRIPTION
See http://blog.chromium.org/2013/02/chrome-26-beta-template-element.html
