### PR TITLE
Mentioned webkit prefix for background-clip: text

### DIFF
--- a/_posts/2013-02-19-background-image-options.md
+++ b/_posts/2013-02-19-background-image-options.md
@@ -1,7 +1,7 @@
 ---
 title: background-image-options
 url: background-img-options
-prefixed: false
+prefixed: true
 ---
 
 <article id="background-image-options" class="feature prefix-{{page.prefixed}}">
@@ -16,15 +16,18 @@ prefixed: false
   /* various options, see e.g. http://www.css3files.com/background */
   background: url(image1.png), 2 url(image2.png), 3 url(image3.png) #FFF;
   background-clip: border-box;
+  /* if value text is used for background-clip, it should be prefixed with webkit */
+  -webkit-background-clip: text;
+  background-clip: text;
   background-origin: padding-box;
   background-size: cover;
 }
 </code></pre>
 	<footer class="feature__footer">
-		<a href="http://caniuse.com/background-img-opts">Browser support</a> 
-		<a href="http://html5please.com/#background-image options">Usage advice</a> 
-		<a href="http://www.css3files.com/background">More info</a> 
-		<a href="https://github.com/davidhund/shouldiprefix/blob/master/_posts/{{page.date | date: "%Y-%m-%d"}}-{{page.title}}.md">Edit this</a> 
+		<a href="http://caniuse.com/background-img-opts">Browser support</a>
+		<a href="http://html5please.com/#background-image options">Usage advice</a>
+		<a href="http://www.css3files.com/background">More info</a>
+		<a href="https://github.com/davidhund/shouldiprefix/blob/master/_posts/{{page.date | date: "%Y-%m-%d"}}-{{page.title}}.md">Edit this</a>
 		<span class="feature__prefix">{{page.prefixed}}</span>
 	</footer>
 </article>

--- a/_posts/2013-02-19-background-image-options.md
+++ b/_posts/2013-02-19-background-image-options.md
@@ -14,9 +14,12 @@ prefixed: true
 <pre class="feature__code"><code>
 .example {
   /* various options, see e.g. http://www.css3files.com/background */
-  background: url(image1.png), 2 url(image2.png), 3 url(image3.png) #FFF;
+  background: url(image1.png), url(image2.png), url(image3.png) #FFF;
   background-clip: border-box;
-  /* if value text is used for background-clip, it should be prefixed with webkit */
+  /*
+  For the not-yet-standard value of ‘text’ WebKit and Edge need `-webkit-`!
+  Firefox supports 'text' without prefixes:
+  */
   -webkit-background-clip: text;
   background-clip: text;
   background-origin: padding-box;


### PR DESCRIPTION
Mentioned the webkit prefix for `background-clip: text;` in `_posts/2013-02-19-background-image-options.md` and changed the `prefixed` value to `true`.